### PR TITLE
Add subscriber's sign out feature

### DIFF
--- a/app/controllers/impact_travel/sessions_controller.rb
+++ b/app/controllers/impact_travel/sessions_controller.rb
@@ -9,6 +9,11 @@ module ImpactTravel
       end
     end
 
+    def destroy
+      destroy_user_sessions
+      redirect_to(landing_path, notice: I18n.t("sessions.destroyed"))
+    end
+
     private
 
     def login
@@ -17,6 +22,10 @@ module ImpactTravel
 
     def authenticated?
       login.authenticate
+    end
+
+    def destroy_user_sessions
+      session[:auth_token] = nil
     end
 
     def login_params

--- a/app/views/layouts/impact_travel/application.html.erb
+++ b/app/views/layouts/impact_travel/application.html.erb
@@ -11,6 +11,7 @@
     <!-- Mobile Metas -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= stylesheet_link_tag "impact_travel/application" %>
+    <%= csrf_meta_tag %>
 
     <!-- Favicons -->
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   sessions:
     created: "You are logged in successfully!"
+    destroyed: "You are logged out successfully!"

--- a/spec/features/subscriber_sign_out_spec.rb
+++ b/spec/features/subscriber_sign_out_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+feature "Subscriber sign out" do
+  scenario "using the logout link" do
+    login_as_valid_subscriber
+    click_on "logout"
+
+    expect(page).not_to have_content("Why Book with")
+    expect(current_path).to eq(impact_travel.landing_path)
+  end
+
+  def login_as_valid_subscriber
+    visit impact_travel.new_session_path
+    subscriber = build(:login)
+    stub_session_create_api(subscriber.attributes)
+
+    fill_in "login_name", with: subscriber.name
+    fill_in "login_password", with: subscriber.password
+    click_on "Login"
+  end
+end


### PR DESCRIPTION
Subscriber can logout simply by clicking the `sign-out` icon form their navigation. This commit also redirect the subscriber to the landing page once they are logged out.