### PR TITLE
Add redirection for logged in user

### DIFF
--- a/app/controllers/impact_travel/application_controller.rb
+++ b/app/controllers/impact_travel/application_controller.rb
@@ -26,5 +26,11 @@ module ImpactTravel
     def set_auth_token
       DiscountNetwork.configuration.auth_token = user_auth_token
     end
+
+    def redirect_logged_in_subscriber
+      if logged_in?
+        redirect_to(home_path)
+      end
+    end
   end
 end

--- a/app/controllers/impact_travel/landings_controller.rb
+++ b/app/controllers/impact_travel/landings_controller.rb
@@ -1,5 +1,7 @@
 module ImpactTravel
   class LandingsController < ApplicationController
+    before_action :redirect_logged_in_subscriber
+
     def show
     end
   end

--- a/app/controllers/impact_travel/sessions_controller.rb
+++ b/app/controllers/impact_travel/sessions_controller.rb
@@ -1,6 +1,7 @@
 module ImpactTravel
   class SessionsController < ApplicationController
     layout "impact_travel/login"
+    before_action :redirect_logged_in_subscriber, except: [:destroy]
 
     def create
       if authenticated?

--- a/spec/features/page_redirection_spec.rb
+++ b/spec/features/page_redirection_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+feature "Page redirection" do
+  scenario "logged in user try to access /landing" do
+    login_with_valid_credentials
+    visit impact_travel.landing_path
+
+    expect(current_path).to eq("/home")
+  end
+
+  scenario "logged in user try to access /sessions/new" do
+    login_with_valid_credentials
+    visit impact_travel.new_session_path
+
+    expect(current_path).to eq("/home")
+  end
+end


### PR DESCRIPTION
Once the user is already logged in then normally he shouldn't be visiting session creation page or landing page. This commit will redirect the logged user from `/sessions` and `/landing` to the subscriber homepage.