### PR TITLE
Handle invalid search creation scenario

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 
 gem "simple_form", "~> 3.2.1"
-gem "discountnetwork", github: "discountnetwork/discountnetwork-ruby", ref: "f1f2928"
+gem "discountnetwork", github: "discountnetwork/discountnetwork-ruby", ref: "c360982"
 gem "factory_girl"
 gem "jquery-rails"
 gem "sass-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/discountnetwork/discountnetwork-ruby.git
-  revision: f1f2928184312e17678b7e41f9f68683c837820a
-  ref: f1f2928
+  revision: c3609820b15336ac6b236be46c1debb681cce675
+  ref: c360982
   specs:
     discountnetwork (0.0.1)
       rest-client (~> 1.8)

--- a/app/models/impact_travel/search.rb
+++ b/app/models/impact_travel/search.rb
@@ -15,6 +15,7 @@ module ImpactTravel
 
     def create
       @response = DiscountNetwork::Search.create(attributes)
+    rescue RestClient::UnprocessableEntity
     end
 
     def search

--- a/app/models/impact_travel/subscriber.rb
+++ b/app/models/impact_travel/subscriber.rb
@@ -1,6 +1,6 @@
 module ImpactTravel
   class Subscriber < ImpactTravel::Base
     attr_accessor :first_name, :last_name, :email, :phone
-    attr_accessor :address, :city, :zip, :country
+    attr_accessor :address, :city, :zip, :country, :token
   end
 end

--- a/spec/controllers/impact_travel/searches_controller_spec.rb
+++ b/spec/controllers/impact_travel/searches_controller_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+describe ImpactTravel::SearchesController do
+  routes { ImpactTravel::Engine.routes }
+
+  describe "#create" do
+    context "with valid search information" do
+      it "creates a new search" do
+        sign_in_as(build(:subscriber))
+        search = build(:search)
+
+        stub_search_create_api(search.attributes)
+        post :create, search: attributes_for(:search)
+
+        expect(flash.notice).to eq(I18n.t("search.create.success"))
+        expect(response).to redirect_to(search_path(search.search_id))
+      end
+    end
+
+    context "with invalid search information" do
+      it "does not create any search" do
+        sign_in_as(build(:subscriber))
+
+        stub_unprocessable_dn_api_request("searches")
+        post(:create, search: attributes_for(:search, location_id: nil))
+
+        expect(response).to redirect_to(home_path)
+        expect(flash.notice).to eq(I18n.t("search.create.errors"))
+      end
+    end
+  end
+
+  def sign_in_as(subscriber)
+    session[:auth_token] = subscriber.token
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     address "House # 1, Main Street"
     city "New York"
     zip "123 ABC"
+    token "ABCD_123"
   end
 
   factory :search, class: ImpactTravel::Search do


### PR DESCRIPTION
In some scenario subscriber might try to create a new search without a valid search information, which will raise an `:unprocessable` error but our application is not processing that error properly which lead to some expected behavior.

This commit adds `Search` controller spec to make sure it's behaving the way it should have and it also properly handle `:unprocessable` API response.