### PR TITLE
Handle invalid search loading

### DIFF
--- a/app/controllers/impact_travel/searches_controller.rb
+++ b/app/controllers/impact_travel/searches_controller.rb
@@ -4,8 +4,9 @@ module ImpactTravel
     before_action :set_auth_token
 
     def show
-      @search = Search.find(params[:id])
-      render layout: "impact_travel/loading"
+      load_search || redirect_to(
+        home_path, notice: I18n.t("search.show.error")
+      )
     end
 
     def create
@@ -27,6 +28,13 @@ module ImpactTravel
 
     def search
       @search = ImpactTravel::Search.new(search_params)
+    end
+
+    def load_search
+      @search = Search.find(params[:id])
+      if @search
+        render(layout: "impact_travel/loading")
+      end
     end
 
     def search_params

--- a/app/models/impact_travel/search.rb
+++ b/app/models/impact_travel/search.rb
@@ -27,6 +27,7 @@ module ImpactTravel
 
     def self.find(search_id)
       DiscountNetwork::Search.find(search_id)
+    rescue RestClient::Unauthorized
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,9 @@ en:
     invalid: "Please re-check your login credentials"
 
   search:
+    show:
+      error: "Does not seams to be a valid search id"
+
     create:
       errors: "There are some errors creating your search"
       success: "Successfully created!, we are working on results"

--- a/spec/controllers/impact_travel/searches_controller_spec.rb
+++ b/spec/controllers/impact_travel/searches_controller_spec.rb
@@ -30,6 +30,36 @@ describe ImpactTravel::SearchesController do
     end
   end
 
+  describe "#show" do
+    context "with valid search id" do
+      it "shows the results loading page" do
+        sign_in_as(build(:subscriber))
+        search = build(:search)
+
+        stub_search_find_api(search.search_id)
+        get :show, id: search.search_id
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(layout: "impact_travel/loading")
+      end
+    end
+
+    context "with invalid search id" do
+      it "redirect to home_path" do
+        sign_in_as(build(:subscriber))
+        search_id = "invalid_id"
+        stub_unauthorized_dn_api_reqeust(
+          ["searches", search_id].join("/"),
+        )
+
+        get :show, id: search_id
+
+        expect(response).to redirect_to(home_path)
+        expect(flash.notice).to eq(I18n.t("search.show.error"))
+      end
+    end
+  end
+
   def sign_in_as(subscriber)
     session[:auth_token] = subscriber.token
   end


### PR DESCRIPTION
If subscriber tries to load some search that has been expired or they are not one who created that, then the app does not behave the way it should have. This commit will handle those invalid search id related issue and this will also send them back to the search creation page.