### PR TITLE
Handle invalid search result request

### DIFF
--- a/app/controllers/impact_travel/results_controller.rb
+++ b/app/controllers/impact_travel/results_controller.rb
@@ -10,12 +10,18 @@ module ImpactTravel
     end
 
     def show
-      @result = Result.find_by(
-        search_id: params[:search_id], hotel_id: params[:id]
+      load_result || redirect_to(
+        home_path, notice: I18n.t("search.invalid")
       )
     end
 
     private
+
+    def load_result
+      @result = Result.find_by(
+        search_id: params[:search_id], hotel_id: params[:id],
+      )
+    end
 
     def load_results
       @results = Result.where(search_id: params[:search_id])

--- a/app/models/impact_travel/result.rb
+++ b/app/models/impact_travel/result.rb
@@ -8,9 +8,8 @@ module ImpactTravel
     end
 
     def find
-      DiscountNetwork::Result.find_by(
-        search_id: search_id, hotel_id: hotel_id
-      )
+      DiscountNetwork::Result.find_by(search_id: search_id, hotel_id: hotel_id)
+    rescue RestClient::Unauthorized
     end
 
     def self.where(search_id:)

--- a/spec/controllers/impact_travel/results_controller_spec.rb
+++ b/spec/controllers/impact_travel/results_controller_spec.rb
@@ -32,4 +32,36 @@ describe ImpactTravel::ResultsController do
       end
     end
   end
+
+  describe "#show" do
+    context "with valid result id" do
+      it "renders the result page" do
+        sign_in_as_subscriber
+        result = build(:result)
+        stub_search_result_api(
+          search_id: result.search_id, hotel_id: result.hotel_id,
+        )
+
+        get(:show, id: result.hotel_id, search_id: result.search_id)
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context "with invalid result id" do
+      it "reidrects to home page" do
+        sign_in_as_subscriber
+        result = build(:result, hotel_id: "invalid_hotel")
+        stub_unauthorized_dn_api_reqeust(
+          ["searches", result.search_id, "results", result.hotel_id].join("/"),
+        )
+
+        get(:show, id: result.hotel_id, search_id: result.search_id)
+
+        expect(response).to redirect_to(home_path)
+        expect(flash.notice).to eq(I18n.t("search.invalid"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the sad case scenario if the subscriber tries to access an invalid hotel id that is not valid for a specific search