### PR TITLE
Handle invalid booking requests

### DIFF
--- a/app/controllers/impact_travel/bookings_controller.rb
+++ b/app/controllers/impact_travel/bookings_controller.rb
@@ -8,9 +8,8 @@ module ImpactTravel
     end
 
     def new
-      @booking = ImpactTravel::Booking.new(
-        search_id: params[:search_id],
-        hotel_id: params[:result_id]
+      valid_result? || redirect_to(
+        home_path, notice: I18n.t("search.invalid")
       )
     end
 
@@ -19,6 +18,17 @@ module ImpactTravel
     end
 
     private
+
+    def valid_result?
+      @result ||= build_booking.result
+    end
+
+    def build_booking
+      @booking ||= ImpactTravel::Booking.new(
+        search_id: params[:search_id],
+        hotel_id: params[:result_id],
+      )
+    end
 
     def create_booking
       if booking.create

--- a/spec/controllers/impact_travel/bookings_controller_spec.rb
+++ b/spec/controllers/impact_travel/bookings_controller_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe ImpactTravel::BookingsController do
+  routes { ImpactTravel::Engine.routes }
+
+  describe "#new" do
+    context "with valid search result" do
+      it "renders the booking form" do
+        sign_in_as_subscriber
+        search_id = 123_456_789
+        result_id = 456_789_012
+        stub_search_result_api(
+          search_id: search_id, hotel_id: result_id,
+        )
+
+        get :new, search_id: search_id, result_id: result_id
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context "with invalid search results" do
+      it "redirects to the home path" do
+        sign_in_as_subscriber
+        search_id = 123_456_789
+        result_id = "invalid_id"
+        stub_unauthorized_dn_api_reqeust(
+          ["searches", search_id, "results", result_id].join("/"),
+        )
+
+        get :new, search_id: search_id, result_id: result_id
+
+        expect(response).to redirect_to(home_path)
+        expect(flash.notice).to eq(I18n.t("search.invalid"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the booking creation the current structure is not doing anything when the `search_id` or `result_id` is not valid, it just throw the error page. This commit add controller specs to verify that user is trying to book a valid search result and it also add that behavior to the bookings controller.