### PR TITLE
Add redirection for invalid booking

### DIFF
--- a/app/controllers/impact_travel/bookings_controller.rb
+++ b/app/controllers/impact_travel/bookings_controller.rb
@@ -4,7 +4,9 @@ module ImpactTravel
     before_action :set_auth_token
 
     def show
-      @booking = ImpactTravel::Booking.find(params[:id])
+      load_booking || redirect_to(
+        home_path, notice: I18n.t("booking.invalid")
+      )
     end
 
     def new
@@ -20,6 +22,10 @@ module ImpactTravel
     end
 
     private
+
+    def load_booking
+      @booking = ImpactTravel::Booking.find(params[:id])
+    end
 
     def valid_result?
       @result ||= build_booking.result

--- a/app/models/impact_travel/booking.rb
+++ b/app/models/impact_travel/booking.rb
@@ -24,6 +24,7 @@ module ImpactTravel
 
     def find
       @response = DiscountNetwork::Booking.find(id)
+    rescue RestClient::UnprocessableEntity
     end
 
     def create

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
       success: "Successfully created!, we are working on results"
 
   booking:
+    invalid: "Does not seams to be a valid booking id"
     confirmation:
       "We have received your booking request, one of our agent will get in
       touch very soon!"

--- a/spec/controllers/impact_travel/bookings_controller_spec.rb
+++ b/spec/controllers/impact_travel/bookings_controller_spec.rb
@@ -3,6 +3,34 @@ require "spec_helper"
 describe ImpactTravel::BookingsController do
   routes { ImpactTravel::Engine.routes }
 
+  describe "#show" do
+    context "with valid booking id" do
+      it "shows the booking confirmation" do
+        sign_in_as_subscriber
+        booking_id = 123_456_789
+
+        stub_booking_find_api(booking_id)
+        get :show, id: booking_id
+
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context "with invalid booking id" do
+      it "redirects to the home page" do
+        sign_in_as_subscriber
+        booking_id = "invalid"
+
+        stub_unprocessable_dn_api_request(["bookings", booking_id].join("/"))
+        get :show, id: booking_id
+
+        expect(response).to redirect_to(home_path)
+        expect(flash.notice).to eq(I18n.t("booking.invalid"))
+      end
+    end
+  end
+
   describe "#new" do
     context "with valid search result" do
       it "renders the booking form" do


### PR DESCRIPTION
Subscriber only have access to their own booking, but if someone try to enter some booking id manually or try to access some booking they don't have access to then they should be redirected to the home page.

This commit adds the redirection for invalid booking requests and it also adds controller specs to ensure both case scenario.