### PR TITLE
Add password changing feature

### DIFF
--- a/app/controllers/impact_travel/accounts_controller.rb
+++ b/app/controllers/impact_travel/accounts_controller.rb
@@ -42,11 +42,6 @@ module ImpactTravel
       redirect_to(new_session_path, notice: I18n.t("account.invalid"))
     end
 
-    def render_with_error(view, message:)
-      flash.now[:error] = message
-      render view.to_sym
-    end
-
     def destroy_user_sessions
       session[:auth_token] = nil
       DiscountNetwork.configuration.auth_token = nil

--- a/app/controllers/impact_travel/application_controller.rb
+++ b/app/controllers/impact_travel/application_controller.rb
@@ -27,6 +27,11 @@ module ImpactTravel
       DiscountNetwork.configuration.auth_token = user_auth_token
     end
 
+    def render_with_error(view, message:)
+      flash.now[:error] = message
+      render view.to_sym
+    end
+
     def redirect_logged_in_subscriber
       if logged_in?
         redirect_to(home_path)

--- a/app/controllers/impact_travel/bookings_controller.rb
+++ b/app/controllers/impact_travel/bookings_controller.rb
@@ -16,8 +16,8 @@ module ImpactTravel
     end
 
     def create
-      create_booking || render_with_message(
-        :new, notice: I18n.t("booking.create.errors")
+      create_booking || render_with_error(
+        :new, message: I18n.t("booking.create.errors")
       )
     end
 
@@ -54,11 +54,6 @@ module ImpactTravel
           hotel_id: params[:result_id],
         ),
       )
-    end
-
-    def render_with_message(view, notice:)
-      flash[:notice] = notice
-      render view.to_sym
     end
 
     def booking_params

--- a/app/controllers/impact_travel/passwords_controller.rb
+++ b/app/controllers/impact_travel/passwords_controller.rb
@@ -24,11 +24,6 @@ module ImpactTravel
       @password ||= ImpactTravel::Password.new(password_params)
     end
 
-    def render_with_error(view, message)
-      flash.now[:error] = message
-      render view.to_sym
-    end
-
     def password_params
       params.require(:password).permit(:password, :password_confirmation)
     end

--- a/app/controllers/impact_travel/passwords_controller.rb
+++ b/app/controllers/impact_travel/passwords_controller.rb
@@ -1,0 +1,36 @@
+module ImpactTravel
+  class PasswordsController < ApplicationController
+    def edit
+      @password = ImpactTravel::Password.new
+    end
+
+    def update
+      update_password || render_with_error(
+        :edit, message: I18n.t("account.update.error")
+      )
+    end
+
+    private
+
+    def update_password
+      if new_password.save
+        redirect_to(
+          account_path, notice: I18n.t("account.updated")
+        )
+      end
+    end
+
+    def new_password
+      @password ||= ImpactTravel::Password.new(password_params)
+    end
+
+    def render_with_error(view, message)
+      flash.now[:error] = message
+      render view.to_sym
+    end
+
+    def password_params
+      params.require(:password).permit(:password, :password_confirmation)
+    end
+  end
+end

--- a/app/models/impact_travel/password.rb
+++ b/app/models/impact_travel/password.rb
@@ -1,0 +1,20 @@
+module ImpactTravel
+  class Password < ImpactTravel::Base
+    attr_accessor :password, :password_confirmation
+    validates :password, presence: true, confirmation: true
+    validates :password, length: { in: 6..20 }
+
+    def attributes
+      {
+        password: password,
+        password_confirmation: password_confirmation,
+      }
+    end
+
+    def save
+      if valid?
+        @response = DiscountNetwork::Account.update(attributes)
+      end
+    end
+  end
+end

--- a/app/views/impact_travel/passwords/_form.html.erb
+++ b/app/views/impact_travel/passwords/_form.html.erb
@@ -1,0 +1,9 @@
+<h4>Change your password</h4>
+<div class="account_holder">
+  <%= simple_form_for @password, url: account_password_path,
+    method: :patch, html: {class: "travelia_form"} do |f| %>
+    <%= f.input :password, label: "New password" %>
+    <%= f.input :password_confirmation, label: "Re-type new password" %>
+    <%= f.button :submit, "Save changes", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/app/views/impact_travel/passwords/edit.html.erb
+++ b/app/views/impact_travel/passwords/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", layout: "account" %>

--- a/spec/controllers/impact_travel/accounts_controller_spec.rb
+++ b/spec/controllers/impact_travel/accounts_controller_spec.rb
@@ -7,7 +7,7 @@ describe ImpactTravel::AccountsController do
     context "valid auth_token exists" do
       it "renders the subscriber profile" do
         sign_in_as_subscriber
-        stub_account_find_api(DiscountNetwork.configuration.auth_token)
+        stub_account_find_api(account_auth_token)
         get :show
 
         expect(response.status).to eq(200)
@@ -71,6 +71,6 @@ describe ImpactTravel::AccountsController do
   end
 
   def stub_valid_subscriber_account
-    stub_account_find_api(DiscountNetwork.configuration.auth_token)
+    stub_account_find_api(account_auth_token)
   end
 end

--- a/spec/controllers/impact_travel/bookings_controller_spec.rb
+++ b/spec/controllers/impact_travel/bookings_controller_spec.rb
@@ -101,7 +101,7 @@ describe ImpactTravel::BookingsController do
 
         expect(response.status).to eq(200)
         expect(response).to render_template(:new)
-        expect(flash.notice).to eq(I18n.t("booking.create.errors"))
+        expect(flash[:error]).to eq(I18n.t("booking.create.errors"))
       end
     end
   end

--- a/spec/controllers/impact_travel/passwords_controller_spec.rb
+++ b/spec/controllers/impact_travel/passwords_controller_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe ImpactTravel::PasswordsController do
+  routes { ImpactTravel::Engine.routes }
+
+  describe "#update" do
+    context "fields do not match the requirements" do
+      it "re renders the password changing form" do
+        sign_in_as_subscriber
+        set_account_auth_configuration
+        password = build(:password, password: "invalid")
+
+        patch :update, password: password.attributes
+
+        expect(assigns(:password)).not_to be_nil
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  def set_account_auth_configuration
+    DiscountNetwork.configuration.auth_token = "ABCD_123"
+  end
+end

--- a/spec/controllers/impact_travel/passwords_controller_spec.rb
+++ b/spec/controllers/impact_travel/passwords_controller_spec.rb
@@ -7,7 +7,7 @@ describe ImpactTravel::PasswordsController do
     context "fields do not match the requirements" do
       it "re renders the password changing form" do
         sign_in_as_subscriber
-        set_account_auth_configuration
+        set_account_auth_token
         password = build(:password, password: "invalid")
 
         patch :update, password: password.attributes
@@ -16,9 +16,5 @@ describe ImpactTravel::PasswordsController do
         expect(response).to render_template(:edit)
       end
     end
-  end
-
-  def set_account_auth_configuration
-    DiscountNetwork.configuration.auth_token = "ABCD_123"
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -61,4 +61,9 @@ FactoryGirl.define do
     hotel_description "This is the description"
     promo_rate "100"
   end
+
+  factory :password, class: ImpactTravel::Password do
+    password "secret_password"
+    password_confirmation "secret_password"
+  end
 end

--- a/spec/features/subscriber_changes_password_spec.rb
+++ b/spec/features/subscriber_changes_password_spec.rb
@@ -3,11 +3,10 @@ require "spec_helper"
 feature "Changing password" do
   scenario "subscriber changes their password" do
     login_with_valid_credentials
-    auth_token = DiscountNetwork.configuration.auth_token
     password = build(:password)
 
-    stub_account_find_api(auth_token)
-    stub_account_update_api(auth_token, password.attributes)
+    stub_account_find_api(account_auth_token)
+    stub_account_update_api(account_auth_token, password.attributes)
 
     click_on "my_account"
     click_on "Change password"

--- a/spec/features/subscriber_changes_password_spec.rb
+++ b/spec/features/subscriber_changes_password_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+feature "Changing password" do
+  scenario "subscriber changes their password" do
+    login_with_valid_credentials
+    auth_token = DiscountNetwork.configuration.auth_token
+    password = build(:password)
+
+    stub_account_find_api(auth_token)
+    stub_account_update_api(auth_token, password.attributes)
+
+    click_on "my_account"
+    click_on "Change password"
+
+    fill_in "New password", with: password.password
+    fill_in "Re-type new password", with: password.password_confirmation
+    click_on "Save changes"
+
+    expect(page).to have_content(I18n.t("account.updated"))
+    expect(current_path).to eq(impact_travel.account_path)
+  end
+end

--- a/spec/features/subscriber_manages_account_spec.rb
+++ b/spec/features/subscriber_manages_account_spec.rb
@@ -3,9 +3,7 @@ require "spec_helper"
 feature "Subscriber profile" do
   scenario "browse their own profile" do
     login_with_valid_credentials
-    stub_account_find_api(
-      DiscountNetwork.configuration.auth_token,
-    )
+    stub_account_find_api(account_auth_token)
 
     click_on "my_account"
 
@@ -16,10 +14,8 @@ feature "Subscriber profile" do
 
   scenario "edit their profile" do
     login_with_valid_credentials
-    stub_account_find_api(DiscountNetwork.configuration.auth_token)
-    stub_account_update_api(
-      DiscountNetwork.configuration.auth_token, subscriber_attributes
-    )
+    stub_account_find_api(account_auth_token)
+    stub_account_update_api(account_auth_token, subscriber_attributes)
 
     click_on "my_account"
     click_on "Edit profile"

--- a/spec/models/impact_travel/password_spec.rb
+++ b/spec/models/impact_travel/password_spec.rb
@@ -3,17 +3,11 @@ require "spec_helper"
 describe ImpactTravel::Password do
   describe "#save" do
     it "save the password changes" do
-      set_account_auth_configuration
+      set_account_auth_token
       password = build(:password)
-      stub_account_update_api(
-        DiscountNetwork.configuration.auth_token, password.attributes
-      )
+      stub_account_update_api(account_auth_token, password.attributes)
 
       expect(password.save).not_to be_nil
     end
-  end
-
-  def set_account_auth_configuration
-    DiscountNetwork.configuration.auth_token = "ABCD_123"
   end
 end

--- a/spec/models/impact_travel/password_spec.rb
+++ b/spec/models/impact_travel/password_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe ImpactTravel::Password do
+  describe "#save" do
+    it "save the password changes" do
+      set_account_auth_configuration
+      password = build(:password)
+      stub_account_update_api(
+        DiscountNetwork.configuration.auth_token, password.attributes
+      )
+
+      expect(password.save).not_to be_nil
+    end
+  end
+
+  def set_account_auth_configuration
+    DiscountNetwork.configuration.auth_token = "ABCD_123"
+  end
+end

--- a/spec/support/sign_in_helper.rb
+++ b/spec/support/sign_in_helper.rb
@@ -6,4 +6,13 @@ module SignInHelpers
   def sign_in_as_subscriber
     sign_in_as(build(:subscriber))
   end
+
+  def account_auth_token
+    @account_auth_token ||= "ABCD_123"
+  end
+
+  def set_account_auth_token
+    @account_auth_token ||=
+      DiscountNetwork.configuration.auth_token = account_auth_token
+  end
 end


### PR DESCRIPTION
This commit adds the necessary changes to allow a logged in subscriber to change their existing password. This does not require subscriber to enter their existing password, but it has some validation in palace to make sure the password matches the system requirements.