### PR TITLE
Add layout option for landing page

### DIFF
--- a/app/controllers/impact_travel/landings_controller.rb
+++ b/app/controllers/impact_travel/landings_controller.rb
@@ -3,6 +3,7 @@ module ImpactTravel
     before_action :redirect_logged_in_subscriber
 
     def show
+      render(layout: "landing")
     end
   end
 end

--- a/app/views/impact_travel/landings/show.html.erb
+++ b/app/views/impact_travel/landings/show.html.erb
@@ -1,2 +1,8 @@
-Override this page in "app/view/landings/show"
+<div>
+  Override this layout in "app/view/layouts/landing" <br />
+  Override this page in "app/view/landings/show"
+</div>
+
+<br />
+
 <%= link_to "Subscriber login", new_session_path %>

--- a/spec/dummy/app/views/layouts/landing.html.erb
+++ b/spec/dummy/app/views/layouts/landing.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Impact Travel</title>
+    <%= csrf_meta_tags %>
+  </head>
+  <body>
+
+    <%= yield %>
+
+  </body>
+</html>


### PR DESCRIPTION
Landing page is rendering the `application` layout, but our main interest in allowing the third party app to customize the landing page as they like and use our engine for backend related features

This commit changes this behavior and expect third party app to add their custom layout for the landing page.