### PR TITLE
Add `forgot password` functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "country_select"
 gem(
   "discountnetwork",
   github: "discountnetwork/discountnetwork-ruby",
-  ref: "859d8ad",
+  ref: "55d8e30",
 )
 gem "factory_girl"
 gem "font-awesome-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/discountnetwork/discountnetwork-ruby.git
-  revision: 859d8ad349d7db5a0d8517ad9f70df46c0717b86
-  ref: 859d8ad
+  revision: 55d8e307b72355fd5b137d02ecf7c85335dd5f39
+  ref: 55d8e30
   specs:
     discountnetwork (0.0.1)
       rest-client (~> 1.8)

--- a/app/controllers/impact_travel/resets_controller.rb
+++ b/app/controllers/impact_travel/resets_controller.rb
@@ -1,0 +1,29 @@
+module ImpactTravel
+  class ResetsController < ApplicationController
+    def new
+      @password_reset = ImpactTravel::PasswordReset.new
+    end
+
+    def create
+      create_password_reset || redirect_to(
+        new_session_path, notice: I18n.t("password_reset.invalid")
+      )
+    end
+
+    private
+
+    def create_password_reset
+      if new_password_reset.save
+        render :confirmation
+      end
+    end
+
+    def new_password_reset
+      @password_reset = ImpactTravel::PasswordReset.new(password_reset_params)
+    end
+
+    def password_reset_params
+      params.require(:password_reset).permit(:email)
+    end
+  end
+end

--- a/app/models/impact_travel/password_reset.rb
+++ b/app/models/impact_travel/password_reset.rb
@@ -1,0 +1,10 @@
+module ImpactTravel
+  class PasswordReset < ImpactTravel::Base
+    attr_accessor :email
+
+    def save
+      @response = DiscountNetwork::Password.forgot(email)
+    rescue RestClient::UnprocessableEntity
+    end
+  end
+end

--- a/app/views/impact_travel/resets/confirmation.html.erb
+++ b/app/views/impact_travel/resets/confirmation.html.erb
@@ -1,0 +1,8 @@
+<h3>Confirmation</h3>
+<p class="text-info">
+We have received your request to change your password. Please check your inbox
+with instructions on how to change the password so that you can get back into
+your account.
+</p>
+
+<%= link_to "Back home", new_session_path, class: "btn btn-primary"%>

--- a/app/views/impact_travel/resets/new.html.erb
+++ b/app/views/impact_travel/resets/new.html.erb
@@ -1,0 +1,8 @@
+<h3>Password reset</h3>
+<%= simple_form_for @password_reset, url: password_reset_path do |f| %>
+  <%= f.input :email, label: false, placeholder: "Enter your email address" %>
+  <%= f.button :submit, "Reset now", class: "btn btn-primary" %>
+<% end %>
+<p class="custom_link">
+<%= link_to "Back home", new_session_path %>
+</p>

--- a/app/views/impact_travel/sessions/new.html.erb
+++ b/app/views/impact_travel/sessions/new.html.erb
@@ -9,7 +9,7 @@
   <%= form.button :submit, "Login", class: "btn btn-primary animated" %>
 
   <p class="custom_link">
-  <%= link_to "Forget your password?", "#" %>
+  <%= link_to "Forgot your password?", new_password_reset_path %>
   </p>
 <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,3 +28,6 @@ en:
 
   activation:
     invalid: "Please provide all the required fields to activate your account"
+
+  password_reset:
+    invalid: "Does not seems to be a valid subscirber email"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,13 @@ ImpactTravel::Engine.routes.draw do
   resources :wellnesses
   resource :account do
     resource :activation
-    resource :password
+    resource :password, only: [:edit, :update]
   end
+
   resources :supplementaries
   resource :contact
+
+  resource :password do
+    resource :reset, only: [:new, :create]
+  end
 end

--- a/spec/controllers/resets_controller_spec.rb
+++ b/spec/controllers/resets_controller_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+describe ImpactTravel::ResetsController do
+  routes { ImpactTravel::Engine.routes }
+
+  describe "#create" do
+    context "with invalid email address" do
+      it "redirect the user to new session path" do
+        invalid_email = "john.doe_example.com"
+        stub_unprocessable_dn_api_request("account/resets")
+
+        post :create, password_reset: { email: invalid_email }
+
+        expect(response).to redirect_to(new_session_path)
+        expect(flash.notice).to eq(I18n.t("password_reset.invalid"))
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -67,4 +67,8 @@ FactoryGirl.define do
     password "secret_password"
     password_confirmation "secret_password"
   end
+
+  factory :password_reset, class: ImpactTravel::PasswordReset do
+    email "john.doe@example.com"
+  end
 end

--- a/spec/features/subscriber_resets_password_spec.rb
+++ b/spec/features/subscriber_resets_password_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+feature "Password reset" do
+  scenario "subscriber resets their password" do
+    email = "john.doe@example.com"
+
+    visit impact_travel.new_session_path
+    click_on "Forgot your password?"
+    stub_password_forgot_api(email)
+
+    fill_in "password_reset_email", with: email
+    click_on "Reset now"
+
+    expect(page).to have_content("We have received your request")
+    expect(current_path).to eq(impact_travel.password_reset_path)
+  end
+end

--- a/spec/models/password_reset_spec.rb
+++ b/spec/models/password_reset_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe ImpactTravel::PasswordReset do
+  describe "#save" do
+    it "saves the password resets through API" do
+      password_reset = build(:password_reset)
+      stub_password_forgot_api(password_reset.email)
+
+      expect(password_reset.save).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the functionality to allow subscribers to submit a password reset request using a valid email address. This will send the request to the API and if it is a valid subscriber email then they will receive an email with password reset instruction