### PR TITLE
Add custom layout for password resets

### DIFF
--- a/app/controllers/impact_travel/passwords_controller.rb
+++ b/app/controllers/impact_travel/passwords_controller.rb
@@ -2,6 +2,7 @@ module ImpactTravel
   class PasswordsController < ApplicationController
     before_action :require_login, except: [:new, :create]
     before_action :set_auth_token, except: [:new, :create]
+    layout "impact_travel/login", only: [:new, :create]
 
     def new
       validate_password_reset || redirect_to(

--- a/app/controllers/impact_travel/resets_controller.rb
+++ b/app/controllers/impact_travel/resets_controller.rb
@@ -1,5 +1,7 @@
 module ImpactTravel
   class ResetsController < ApplicationController
+    layout "impact_travel/login"
+
     def show
       validated_password_reset || redirect_to(
         new_session_path, notice: I18n.t("password_reset.invalid_token")


### PR DESCRIPTION
Currently password resets related pages are using the application layout, which does not include the custom format we require, so adding the `login` layout will give it a pretty new look.