### PR TITLE
Set root path to `landings#show`

### DIFF
--- a/app/views/impact_travel/passwords/new.html.erb
+++ b/app/views/impact_travel/passwords/new.html.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <p class="custom_link">
-<%= link_to "Back home", new_session_path %>
+<%= link_to "Back home", root_path %>
 </p>

--- a/app/views/impact_travel/resets/confirmation.html.erb
+++ b/app/views/impact_travel/resets/confirmation.html.erb
@@ -5,4 +5,4 @@ with instructions on how to change the password so that you can get back into
 your account.
 </p>
 
-<%= link_to "Back home", new_session_path, class: "btn btn-primary"%>
+<%= link_to "Back home", root_path, class: "btn btn-primary"%>

--- a/app/views/impact_travel/resets/new.html.erb
+++ b/app/views/impact_travel/resets/new.html.erb
@@ -4,5 +4,5 @@
   <%= f.button :submit, "Reset now", class: "btn btn-primary" %>
 <% end %>
 <p class="custom_link">
-<%= link_to "Back home", new_session_path %>
+<%= link_to "Back home", root_path %>
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 ImpactTravel::Engine.routes.draw do
+  root "landings#show"
+
   resource :landing
   resources :sessions
   resource :home


### PR DESCRIPTION
Currently there is nothing in the engine's root path, this commit changes this and sets engine's root path to the `landings#show`. The best thing is landing page also redirects the logged in user to the home path, so we don't need to worry about that :)