### PR TITLE
Add `/home` and `/shopping` links

### DIFF
--- a/app/controllers/impact_travel/shoppings_controller.rb
+++ b/app/controllers/impact_travel/shoppings_controller.rb
@@ -1,0 +1,9 @@
+module ImpactTravel
+  class ShoppingsController < ApplicationController
+    before_action :require_login
+
+    def show
+      redirect_to("https://discountnetwork.enjoymydeals.com")
+    end
+  end
+end

--- a/app/views/impact_travel/application/_header.html.erb
+++ b/app/views/impact_travel/application/_header.html.erb
@@ -1,18 +1,14 @@
 <header id="header" class="header-v1">
-  <!-- Main Nav -->
   <nav class="flat-mega-menu">
-    <!-- flat-mega-menu class -->
-    <label for="mobile-button"> <i class="fa fa-bars"></i></label><!-- mobile click button to show menu -->
+    <label for="mobile-button"><i class="fa fa-bars"></i></label>
     <input id="mobile-button" type="checkbox">
 
     <ul class="collapse">
       <li class="title">
-      <%= link_to image_tag(site_logo, class: "navbar_logo"), "#" %>
+      <%= link_to(image_tag(site_logo, class: "navbar_logo"), home_path) %>
     </li>
 
-    <!-- site navigation -->
     <%= render "navigation" %>
-    <!-- site navigation -->
 
     <% if logged_in? %>
       <li class="login-form">
@@ -39,6 +35,6 @@
         ) %>
       </li>
     <% end %>
-    </ul> </nav>
-    <!-- Main Nav -->
+    </ul>
+  </nav>
 </header>

--- a/app/views/impact_travel/application/_navigation.html.erb
+++ b/app/views/impact_travel/application/_navigation.html.erb
@@ -1,5 +1,5 @@
 <li><%= link_to "HOTELS", hotels_path %></li>
-<li><%= link_to "SHOPPING", "#", target: "_blank" %></li>
+<li><%= link_to "SHOPPING", shopping_path, target: "_blank" %></li>
 <li><%= link_to "CONDOS", condos_path  %></li>
 <li><%= link_to "PACKAGES", packages_path %></li>
 <li>

--- a/app/views/impact_travel/homes/show.html.erb
+++ b/app/views/impact_travel/homes/show.html.erb
@@ -138,7 +138,7 @@
                 <% end %>
               </li>
               <li>
-                <%= link_to shopping_path do %>
+                <%= link_to shopping_path, target: "_blank" do %>
                   <div class="item-service-line">
                     <i class="fa fa-shopping-cart"></i>
                     <h5>Shopping</h5>


### PR DESCRIPTION
In the engine, we did not have any link to go back to home and also the shopping partner. This commit adds the `/home` link to the logo and it also add `shopping` link that redirect to the shopping site