### PR TITLE
Add support for custom stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ ImpactTravel.configure do |config|
   config.title = "Application Name / Title"
   config.abbreviation = "Application abbreviation"
   config.phone = "Contact Number for the app"
+  config.stylesheet = "custom.stylesheet"
 
   # Search engine meta attributes
   config.keywords = "Keywords for meta attribute"

--- a/app/helpers/impact_travel/theme_helper.rb
+++ b/app/helpers/impact_travel/theme_helper.rb
@@ -12,6 +12,10 @@ module ImpactTravel
       @site_title ||= ImpactTravel.configuration.title
     end
 
+    def site_stylesheet
+      @site_stylesheet ||= ImpactTravel.configuration.stylesheet
+    end
+
     def site_keywords
       @site_keywords ||= ImpactTravel.configuration.keywords
     end

--- a/app/views/layouts/impact_travel/application.html.erb
+++ b/app/views/layouts/impact_travel/application.html.erb
@@ -12,6 +12,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= favicon_link_tag("favicon.png", rel: "icon", type: "image/png") %>
     <%= stylesheet_link_tag "impact_travel/application" %>
+
+    <% unless site_stylesheet.nil? %>
+      <%= stylesheet_link_tag(site_stylesheet) %>
+    <% end %>
+
     <%= csrf_meta_tag %>
 
     <!-- Favicons -->

--- a/app/views/layouts/impact_travel/loading.html.erb
+++ b/app/views/layouts/impact_travel/loading.html.erb
@@ -7,6 +7,10 @@
     <meta name="description" content="<%= site_description %>">
     <meta name="author" content="<%= site_author %>">
     <%= stylesheet_link_tag "impact_travel/loading" %>
+
+    <% unless site_stylesheet.nil? %>
+      <%= stylesheet_link_tag(site_stylesheet) %>
+    <% end %>
   </head>
 
   <body class="full">

--- a/app/views/layouts/impact_travel/login.html.erb
+++ b/app/views/layouts/impact_travel/login.html.erb
@@ -12,6 +12,10 @@
     <%= favicon_link_tag("favicon.png", rel: "icon", type: "image/png") %>
     <%= stylesheet_link_tag "impact_travel/application" %>
     <%= stylesheet_link_tag "impact_travel/login" %>
+
+    <% unless site_stylesheet.nil? %>
+      <%= stylesheet_link_tag(site_stylesheet) %>
+    <% end %>
   </head>
 
   <body>

--- a/lib/impact_travel/configuration.rb
+++ b/lib/impact_travel/configuration.rb
@@ -1,7 +1,7 @@
 module ImpactTravel
   class Configuration
     attr_accessor :api_key, :logo, :title, :abbreviation
-    attr_accessor :keywords, :description, :author, :phone
+    attr_accessor :stylesheet, :keywords, :description, :author, :phone
   end
 
   def self.configure

--- a/spec/dummy/app/assets/stylesheets/custom.style.css
+++ b/spec/dummy/app/assets/stylesheets/custom.style.css
@@ -1,0 +1,3 @@
+#header img.navbar_logo{
+  width: 160px;
+}

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,2 +1,3 @@
 Rails.application.config.assets.version = "1.0"
 Rails.application.config.assets.precompile += %w(impact_travel/login.css)
+Rails.application.config.assets.precompile += %w(custom.style)

--- a/spec/dummy/config/initializers/impact_travel.rb
+++ b/spec/dummy/config/initializers/impact_travel.rb
@@ -5,6 +5,7 @@ ImpactTravel.configure do |config|
   config.phone = "+1 888 123 456 7890"
   config.abbreviation = "DN"
 
+  config.stylesheet = "custom.style"
   config.keywords = "Travel, Leisure, Discount, Tours, Cruises"
   config.description = "Best travel and leisure discount provider"
   config.author = "Impact Services"

--- a/spec/impact_travel/configuration_spec.rb
+++ b/spec/impact_travel/configuration_spec.rb
@@ -22,6 +22,7 @@ describe ImpactTravel::Configuration do
       site_keywords = "travel, discount"
       site_description = "Travel the world in cheapest price"
       site_author = "Impact Services"
+      site_stylesheet = "custom"
 
       ImpactTravel.configure do |config|
         config.logo = site_logo
@@ -31,6 +32,7 @@ describe ImpactTravel::Configuration do
         config.description = site_description
         config.author = site_author
         config.phone = site_contact
+        config.stylesheet = site_stylesheet
       end
 
       configuration = ImpactTravel.configuration
@@ -40,6 +42,7 @@ describe ImpactTravel::Configuration do
       expect(configuration.phone).to eq(site_contact)
       expect(configuration.author).to eq(site_author)
       expect(configuration.keywords).to eq(site_keywords)
+      expect(configuration.stylesheet).to eq(site_stylesheet)
       expect(configuration.description).to eq(site_description)
       expect(configuration.abbreviation).to eq(site_abbreviation)
     end


### PR DESCRIPTION
Each white label will have their custom style preference on the existing design. This commit adds the support for custom styles, so all they need to do is add one compiled stylesheet manifest and then add it to the engine configuration, engine will do the rest to include it in each layout file, and remember this will also override any existing styles. Configuration:

```ruby
ImpactTravel.configuration.stylesheet = "custom.stylesheet"
```