### PR TITLE
Fix missing translation for hotels

### DIFF
--- a/app/controllers/impact_travel/hotels_controller.rb
+++ b/app/controllers/impact_travel/hotels_controller.rb
@@ -5,10 +5,5 @@ module ImpactTravel
     def provider_type
       @provider_type ||= "hotel"
     end
-
-    def set_page_attributes
-      @page_title = "Hotels"
-      @page_subtitle = "This is the sub title for the hotel"
-    end
   end
 end

--- a/app/views/impact_travel/providers/index.html.erb
+++ b/app/views/impact_travel/providers/index.html.erb
@@ -60,7 +60,7 @@
                   <% if provider.postable == true %>
                     <%= form_for :postable, url: provider.link do |f| %>
                       <%= f.submit(
-                        I18n.t("impact_travel.provider.browse_button"),
+                        I18n.t("impact_travel.providers.book_now"),
                         class: "btn btn-primary"
                       )%>
                     <% end %>

--- a/config/locales/providers.en.yml
+++ b/config/locales/providers.en.yml
@@ -2,6 +2,13 @@ en:
   impact_travel:
     providers:
       browse_button: "Browse now"
+      book_now: "Book now"
+
+      hotel:
+        title: "Hotels"
+        subtitle:
+          "Hotels can be booked live online or by submitting a request
+          to our concierge team."
 
       resort:
         title: "Condos"


### PR DESCRIPTION
In the `hotel` provider we were manually specifying the page attribute, instead of using the configuration option. This was causing issue with configuring content. This commit fix it by adding configuration support for `hotel` providers.