### PR TITLE
Add social media links config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ ImpactTravel.configure do |config|
   config.keywords = "Keywords for meta attribute"
   config.description = "Description for meta attribute"
   config.author = "Author for meta attribute"
+
+  # Social media pages
+  config.facebook = "https://facebook.com/your-page"
+  config.twitter = "https://twitter.com/your-page"
+  config.instagram = "https://instagram.com/your-page"
 end
 ```
 

--- a/app/helpers/impact_travel/theme_helper.rb
+++ b/app/helpers/impact_travel/theme_helper.rb
@@ -36,6 +36,14 @@ module ImpactTravel
       @site_abbreviation ||= ImpactTravel.configuration.abbreviation
     end
 
+    def social_links
+      @social_links ||= OpenStruct.new(
+        facebook: ImpactTravel.configuration.facebook,
+        twitter: ImpactTravel.configuration.twitter,
+        instagram: ImpactTravel.configuration.instagram,
+      )
+    end
+
     def font_awesome(icon_name)
       "<i class='fa #{icon_name}'></i>".html_safe
     end

--- a/app/views/impact_travel/application/_navigation.html.erb
+++ b/app/views/impact_travel/application/_navigation.html.erb
@@ -16,8 +16,28 @@
 
 <li class="social-bar"> <a href="#">FOLLOW US</a>
   <ul class="drop-down hover-zoom">
-    <li><a href="#" target="_blank"><i class="fa fa-twitter"></i> </a> </li>
-    <li><a href="#" target="_blank"><i class="fa fa-instagram"></i> </a> </li>
-    <li><a href="#" target="_blank"><i class="fa fa-facebook"></i> </a> </li>
+    <% if social_links.twitter %>
+      <li>
+        <a href="<%= social_links.twitter %>" target="_blank">
+          <i class="fa fa-twitter"></i>
+        </a>
+      </li>
+    <% end %>
+
+    <% if social_links.instagram %>
+      <li>
+        <a href="<%= social_links.instagram %>" target="_blank">
+          <i class="fa fa-instagram"></i>
+        </a>
+      </li>
+    <% end %>
+
+    <% if social_links.facebook %>
+      <li>
+        <a href="<%= social_links.facebook %>" target="_blank">
+          <i class="fa fa-facebook"></i>
+        </a>
+      </li>
+    <% end %>
   </ul>
 </li>

--- a/lib/impact_travel/configuration.rb
+++ b/lib/impact_travel/configuration.rb
@@ -1,7 +1,8 @@
 module ImpactTravel
   class Configuration
     attr_accessor :api_key, :logo, :title, :abbreviation
-    attr_accessor :stylesheet, :keywords, :description, :author, :phone
+    attr_accessor :stylesheet, :keywords, :description, :author
+    attr_accessor :phone, :facebook, :twitter, :instagram
   end
 
   def self.configure

--- a/spec/dummy/config/initializers/impact_travel.rb
+++ b/spec/dummy/config/initializers/impact_travel.rb
@@ -9,4 +9,6 @@ ImpactTravel.configure do |config|
   config.keywords = "Travel, Leisure, Discount, Tours, Cruises"
   config.description = "Best travel and leisure discount provider"
   config.author = "Impact Services"
+
+  config.facebook = "https://facebook.com/facebook"
 end

--- a/spec/impact_travel/configuration_spec.rb
+++ b/spec/impact_travel/configuration_spec.rb
@@ -47,4 +47,22 @@ describe ImpactTravel::Configuration do
       expect(configuration.abbreviation).to eq(site_abbreviation)
     end
   end
+
+  describe "social links" do
+    it "returns the social link configurations" do
+      facebook = "https://facebook.com/example-page"
+      twitter = "https://twitter.com/example-page"
+      instagram = "https://instagram.com/example-page"
+
+      ImpactTravel.configure do |config|
+        config.facebook = facebook
+        config.twitter = twitter
+        config.instagram = instagram
+      end
+
+      expect(ImpactTravel.configuration.facebook).to eq(facebook)
+      expect(ImpactTravel.configuration.twitter).to eq(twitter)
+      expect(ImpactTravel.configuration.instagram).to eq(instagram)
+    end
+  end
 end


### PR DESCRIPTION
This commit adds the support for social media links, so developer can specify the social media links as configuration and the app will automatically use it whenever it is necessary.

```ruby
ImpactTravel.configure do |config|
  config.facebook = "https://facebook.com/facebook"
  config.twitter = "https://twitter.com/twitter"
  config.instagram = "https://instagram.com/instagram"
end
```