### PR TITLE
Add application's about page

### DIFF
--- a/app/controllers/impact_travel/abouts_controller.rb
+++ b/app/controllers/impact_travel/abouts_controller.rb
@@ -1,0 +1,5 @@
+module ImpactTravel
+  class AboutsController < ApplicationController
+    before_action :require_login
+  end
+end

--- a/app/views/impact_travel/abouts/show.html.erb
+++ b/app/views/impact_travel/abouts/show.html.erb
@@ -1,0 +1,29 @@
+<!-- Section Title-->
+<div class="section-title-01">
+  <div class="bg_parallax image_02_parallax"></div>
+
+  <div class="opacy_bg_02">
+    <div class="container">
+      <h1>About us</h1>
+      <div class="crumbs">
+        <ul>
+          <li><%= raw("&nbsp;" * 60) %></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+<section class="content-central">
+  <div class="semiboxshadow text-center">
+    <%= image_tag "impact_travel/result-bg.png", class: "img-responsive" %>
+  </div>
+
+  <div class="content_info">
+    <div class="paddings-mini">
+      <div class="container about_us">
+        <%= render "content" %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/impact_travel/application/_content.html.erb
+++ b/app/views/impact_travel/application/_content.html.erb
@@ -1,0 +1,1 @@
+Sample Content

--- a/app/views/impact_travel/application/_navigation.html.erb
+++ b/app/views/impact_travel/application/_navigation.html.erb
@@ -11,7 +11,7 @@
   </ul>
 </li>
 
-<li><%= link_to "ABOUT", "#" %></li>
+<li><%= link_to "ABOUT", about_path %></li>
 <!-- <li> <%= link_to "CONTACT", "#" %></li> -->
 
 <li class="social-bar"> <a href="#">FOLLOW US</a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ ImpactTravel::Engine.routes.draw do
 
   resources :supplementaries
   resource :contact
+  resource :about
 
   resource :password do
     resources :resets

--- a/spec/features/about_us_page_spec.rb
+++ b/spec/features/about_us_page_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+feature "About Us" do
+  scenario "subscriber browse about us page" do
+    login_with_valid_credentials
+    click_on "ABOUT"
+
+    expect(page).to have_content("About Us")
+    expect(page).to have_content("Sample Content")
+  end
+end


### PR DESCRIPTION
This commit adds the about us for the application, this commit also usages a `content` partial, the developer needs to override this partial in their application then it will automatically use the content from that partial template.