### PR TITLE
Remove guests number from search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impact_travel (0.0.1)
+    impact_travel (0.1.0)
       bootstrap-sass (~> 3.3.7)
       coffee-rails
       country_select
@@ -66,9 +66,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    coffee-rails (4.1.1)
+    coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.1.x)
+      railties (>= 4.0.0, < 5.2.x)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -92,8 +92,8 @@ GEM
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
-    font-awesome-rails (4.5.0.0)
-      railties (>= 3.2, < 5.0)
+    font-awesome-rails (4.7.0.0)
+      railties (>= 3.2, < 5.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
@@ -180,10 +180,10 @@ GEM
       activemodel (> 4, < 5.1)
     sort_alphabetical (1.0.2)
       unicode_utils (>= 1.2.2)
-    sprockets (3.6.3)
+    sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -201,7 +201,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    will_paginate (3.0.7)
+    will_paginate (3.0.12)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 

--- a/app/models/impact_travel/search.rb
+++ b/app/models/impact_travel/search.rb
@@ -9,7 +9,7 @@ module ImpactTravel
         location_name: destination,
         check_in: check_in,
         check_out: check_out,
-        adults: guests,
+        adults: guests || 2,
       }
     end
 

--- a/app/views/impact_travel/homes/show.html.erb
+++ b/app/views/impact_travel/homes/show.html.erb
@@ -42,13 +42,6 @@
         <%= f.input :check_out, placeholder: "Check Out", label: false,
           input_html: {class: "date-input"} %>
 
-        <div class="selector">
-          <%= f.input :guests, as: :select, collection: guests_collection,
-            prompt: false, label: false, selected: 2,
-            input_html: {class: "guests-input"} %>
-          <span class="custom-select">Guests</span>
-        </div>
-
         <%= f.submit "Search" %>
       <% end %>
     </div>

--- a/spec/features/subscriber_creates_a_new_search_spec.rb
+++ b/spec/features/subscriber_creates_a_new_search_spec.rb
@@ -11,7 +11,6 @@ feature "New Search" do
     fill_in "search_destination", with: search.destination
     fill_in "search_check_in", with: search.check_in
     fill_in "search_check_out", with: search.check_out
-    select "2 Guests", from: "search_guests"
     find("input#search_location_id", visible: false).set(
       search.location_id,
     )

--- a/vendor/assets/stylesheets/travelia/style.scss
+++ b/vendor/assets/stylesheets/travelia/style.scss
@@ -839,15 +839,15 @@ hr.tall{
   border-right: 0;
 }
 .filter-header .input-large{
-  width: 35%;
   background: #fff asset-url("travelia/location.png") no-repeat scroll left 6px;
   padding-left: 40px;
+  width: 40%;
 }
 .filter-header .date-input{
-  width: 17%;
   background: #fff asset-url("travelia/calendar.png") no-repeat scroll right 12px;
-  padding-right: 10px;
   font-size: 0.9rem;
+  padding-right: 10px;
+  width: 22%;
 }
 .filter-header .selector{
   position: relative;


### PR DESCRIPTION
We only have guest numbers on the home page, but it does not specify how they want to organize those guest in rooms, and it was causing some confusions. So lets remove this until we something otherwise