### PR TITLE
Add support for multiple logos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impact_travel (0.1.0)
+    impact_travel (0.1.2)
       bootstrap-sass (~> 3.3.7)
       coffee-rails
       country_select
@@ -86,7 +86,7 @@ GEM
     diff-lcs (1.2.5)
     discountnetwork (0.1.0)
       rest-client (~> 1.8)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20161021)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -101,7 +101,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     i18n_data (0.7.0)
-    jquery-rails (4.1.1)
+    jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ initializer to set up your configuration.
 ImpactTravel.configure do |config|
   config.api_key = "DISOUNT_NETWORK_API_KEY"
   config.logo = "logo-name.png"
+  config.logo_inverse = "logo-inverse.png"
 
   # Application attributes
   config.title = "Application Name / Title"

--- a/app/helpers/impact_travel/theme_helper.rb
+++ b/app/helpers/impact_travel/theme_helper.rb
@@ -8,6 +8,10 @@ module ImpactTravel
       @site_logo ||= ImpactTravel.configuration.logo
     end
 
+    def site_sticky_logo
+      @site_sticky_logo ||= ImpactTravel.configuration.logo_inverse || site_logo
+    end
+
     def site_title
       @site_title ||= ImpactTravel.configuration.title
     end

--- a/app/views/impact_travel/application/_header.html.erb
+++ b/app/views/impact_travel/application/_header.html.erb
@@ -5,8 +5,12 @@
 
     <ul class="collapse">
       <li class="title">
-      <%= link_to(image_tag(site_logo, class: "navbar_logo"), home_path) %>
-    </li>
+        <%= link_to(image_tag(site_logo, class: "navbar_logo"), home_path) %>
+        <%= link_to(
+            image_tag(site_sticky_logo, class: "navbar_logo logo_sticky"),
+            home_path
+          ) %>
+      </li>
 
     <%= render "navigation" %>
 

--- a/lib/impact_travel/configuration.rb
+++ b/lib/impact_travel/configuration.rb
@@ -1,8 +1,8 @@
 module ImpactTravel
   class Configuration
-    attr_accessor :api_key, :logo, :title, :abbreviation
-    attr_accessor :stylesheet, :keywords, :description, :author
-    attr_accessor :phone, :facebook, :twitter, :instagram, :slides
+    attr_accessor :api_key, :logo, :logo_inverse, :title, :abbreviation
+    attr_accessor :stylesheet, :keywords, :description, :author, :phone
+    attr_accessor :facebook, :twitter, :instagram, :slides
 
     def initialize
       @slides ||= ["impact_travel/slide.jpg"]

--- a/spec/impact_travel/configuration_spec.rb
+++ b/spec/impact_travel/configuration_spec.rb
@@ -26,6 +26,7 @@ describe ImpactTravel::Configuration do
 
       ImpactTravel.configure do |config|
         config.logo = site_logo
+        config.logo_inverse = site_logo
         config.title = site_title
         config.abbreviation = site_abbreviation
         config.keywords = site_keywords
@@ -38,6 +39,7 @@ describe ImpactTravel::Configuration do
       configuration = ImpactTravel.configuration
 
       expect(configuration.logo).to eq(site_logo)
+      expect(configuration.logo_inverse).to eq(site_logo)
       expect(configuration.title).to eq(site_title)
       expect(configuration.phone).to eq(site_contact)
       expect(configuration.author).to eq(site_author)

--- a/vendor/assets/stylesheets/travelia/customization.css
+++ b/vendor/assets/stylesheets/travelia/customization.css
@@ -11,6 +11,14 @@ img.navbar_logo.logo_sticky{
   display: none;
 }
 
+.sticky-wrapper.is-sticky img.navbar_logo{
+  display: none;
+}
+
+.sticky-wrapper.is-sticky img.navbar_logo.logo_sticky{
+  display: inline;
+}
+
 .title-header h1{
   text-transform: uppercase;
 }


### PR DESCRIPTION
On the theme, based on scrolling we have support for different logos but we only allow to set one logo via configuration. This commit adds the support for different logos and those can be setted up via the configuration. Usages

```ruby
ImpactTravel.configure do |config|
  config.logo = "logo.png"
  config.logo_inverse = "logo-inverse.png"
end
```