### PR TITLE
Remove module like namespaces

### DIFF
--- a/app/controllers/impact_travel/abouts_controller.rb
+++ b/app/controllers/impact_travel/abouts_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class AboutsController < ApplicationController
+  class AboutsController < ImpactTravel::ApplicationController
     before_action :require_login
   end
 end

--- a/app/controllers/impact_travel/accounts_controller.rb
+++ b/app/controllers/impact_travel/accounts_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class AccountsController < ApplicationController
+  class AccountsController < ImpactTravel::ApplicationController
     before_action :require_login
     before_action :set_auth_token
 

--- a/app/controllers/impact_travel/activations_controller.rb
+++ b/app/controllers/impact_travel/activations_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class ActivationsController < ApplicationController
+  class ActivationsController < ImpactTravel::ApplicationController
     def show
       set_activation_session(activation_token)
       redirect_to(new_account_activation_path)

--- a/app/controllers/impact_travel/bookings_controller.rb
+++ b/app/controllers/impact_travel/bookings_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class BookingsController < ApplicationController
+  class BookingsController < ImpactTravel::ApplicationController
     before_action :require_login
     before_action :set_auth_token
 

--- a/app/controllers/impact_travel/destinations_controller.rb
+++ b/app/controllers/impact_travel/destinations_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class DestinationsController < ApplicationController
+  class DestinationsController < ImpactTravel::ApplicationController
     def index
       render json: similar_destinations
     end

--- a/app/controllers/impact_travel/homes_controller.rb
+++ b/app/controllers/impact_travel/homes_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class HomesController < ApplicationController
+  class HomesController < ImpactTravel::ApplicationController
     before_action :require_login
 
     def show

--- a/app/controllers/impact_travel/landings_controller.rb
+++ b/app/controllers/impact_travel/landings_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class LandingsController < ApplicationController
+  class LandingsController < ImpactTravel::ApplicationController
     before_action :redirect_logged_in_subscriber
 
     def show

--- a/app/controllers/impact_travel/passwords_controller.rb
+++ b/app/controllers/impact_travel/passwords_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class PasswordsController < ApplicationController
+  class PasswordsController < ImpactTravel::ApplicationController
     before_action :require_login, except: [:new, :create]
     before_action :set_auth_token, except: [:new, :create]
     layout "impact_travel/login", only: [:new, :create]

--- a/app/controllers/impact_travel/providers_controller.rb
+++ b/app/controllers/impact_travel/providers_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class ProvidersController < ApplicationController
+  class ProvidersController < ImpactTravel::ApplicationController
     before_action :require_login
 
     def index

--- a/app/controllers/impact_travel/resets_controller.rb
+++ b/app/controllers/impact_travel/resets_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class ResetsController < ApplicationController
+  class ResetsController < ImpactTravel::ApplicationController
     layout "impact_travel/login"
 
     def show

--- a/app/controllers/impact_travel/searches_controller.rb
+++ b/app/controllers/impact_travel/searches_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class SearchesController < ApplicationController
+  class SearchesController < ImpactTravel::ApplicationController
     before_action :require_login
     before_action :set_auth_token
 

--- a/app/controllers/impact_travel/sessions_controller.rb
+++ b/app/controllers/impact_travel/sessions_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class SessionsController < ApplicationController
+  class SessionsController < ImpactTravel::ApplicationController
     layout "impact_travel/login"
     before_action :redirect_logged_in_subscriber, except: [:destroy]
 

--- a/app/controllers/impact_travel/shoppings_controller.rb
+++ b/app/controllers/impact_travel/shoppings_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class ShoppingsController < ApplicationController
+  class ShoppingsController < ImpactTravel::ApplicationController
     before_action :require_login
 
     def show

--- a/app/controllers/impact_travel/supplementaries_controller.rb
+++ b/app/controllers/impact_travel/supplementaries_controller.rb
@@ -1,5 +1,5 @@
 module ImpactTravel
-  class SupplementariesController < ApplicationController
+  class SupplementariesController < ImpactTravel::ApplicationController
     before_action :require_login
     before_action :set_auth_token
 


### PR DESCRIPTION
About us controller and Accounts controller is causing some issue in some application. This commit fixes this issue by adding namespace in the inherited controller. So instead of inheriting `ApplicationController`, it will inherit from `ImpactTravel::ApplicationController`.