### PR TITLE
Use singular `session` as resource

### DIFF
--- a/app/controllers/impact_travel/sessions_controller.rb
+++ b/app/controllers/impact_travel/sessions_controller.rb
@@ -4,17 +4,14 @@ module ImpactTravel
     before_action :redirect_logged_in_subscriber, except: [:destroy]
 
     def create
-      if authenticated?
-        sign_in(@login.subscriber)
-        redirect_to(home_path, notice: I18n.t("sessions.created"))
-      else
-        redirect_to(new_session_path, notice: I18n.t("sessions.invalid"))
-      end
+      create_session || redirect_to(
+        new_session_path, notice: I18n.t("session.invalid")
+      )
     end
 
     def destroy
       destroy_user_sessions
-      redirect_to(landing_path, notice: I18n.t("sessions.destroyed"))
+      redirect_to(landing_path, notice: I18n.t("session.destroyed"))
     end
 
     private
@@ -23,8 +20,11 @@ module ImpactTravel
       @login = Login.new(login_params)
     end
 
-    def authenticated?
-      login.authenticate
+    def create_session
+      if login.authenticate
+        sign_in(@login.subscriber)
+        redirect_to(home_path, notice: I18n.t("session.created"))
+      end
     end
 
     def destroy_user_sessions

--- a/app/views/impact_travel/application/_header.html.erb
+++ b/app/views/impact_travel/application/_header.html.erb
@@ -18,7 +18,7 @@
       <li class="login-form">
         <%= link_to(
           font_awesome("fa-sign-out"),
-          session_path(Time.now.to_i),
+          session_path,
           method: :delete,
           id: "logout"
         ) %>

--- a/app/views/impact_travel/sessions/new.html.erb
+++ b/app/views/impact_travel/sessions/new.html.erb
@@ -3,7 +3,7 @@
   <p class="alert alert-info"><%= msg %></p>
 <% end %>
 
-<%= simple_form_for :login, url: sessions_path do |form| %>
+<%= simple_form_for :login, url: session_path do |form| %>
   <%= form.input :name, label: false, placeholder: "Email or Username" %>
   <%= form.input :password, label: false, placeholder: "Password" %>
   <%= form.button(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
-  sessions:
+  session:
     created: "You are logged in successfully!"
     destroyed: "You are logged out successfully!"
     invalid: "Please re-check your login credentials"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ ImpactTravel::Engine.routes.draw do
   root "landings#show"
 
   resource :landing
-  resources :sessions
+  resource :session
   resource :home
   resources :destinations
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -11,7 +11,7 @@ describe ImpactTravel::SessionsController do
         post :create, login: login_params(subscriber)
 
         expect(response).to redirect_to(home_path)
-        expect(flash.notice).to eq(I18n.t("sessions.created"))
+        expect(flash.notice).to eq(I18n.t("session.created"))
       end
     end
 
@@ -22,7 +22,7 @@ describe ImpactTravel::SessionsController do
         post :create, login: login_params(subscriber)
 
         expect(response).to redirect_to(new_session_path)
-        expect(flash.notice).to eq(I18n.t("sessions.invalid"))
+        expect(flash.notice).to eq(I18n.t("session.invalid"))
       end
     end
   end


### PR DESCRIPTION
The existing version was using plural `sessions`, which requires us to pass some take data on the delete, and it did not look that clean. This commit changes it to a singular resource and it also do a minor cleanup on the sessions controller.