### PR TITLE
Specify `en` as default locale

### DIFF
--- a/app/controllers/impact_travel/application_controller.rb
+++ b/app/controllers/impact_travel/application_controller.rb
@@ -1,6 +1,7 @@
 module ImpactTravel
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
+    before_action :set_locale
     helper_method :logged_in?
 
     def require_login
@@ -40,6 +41,10 @@ module ImpactTravel
       if logged_in?
         redirect_to(home_path)
       end
+    end
+
+    def set_locale
+      I18n.locale = I18n.default_locale
     end
   end
 end


### PR DESCRIPTION
Some white label are using multiple languages for their landing page, and when a subscriber is coming from that landing page and a different locale then the engine is not behaving as expected.

This commit will set the `en` as default, so no matter what it will always work as expected. Once we have support for other languages then we can implement some configuration.