### PR TITLE
Extract background from loading page

### DIFF
--- a/app/assets/stylesheets/impact_travel/loading.scss
+++ b/app/assets/stylesheets/impact_travel/loading.scss
@@ -7,6 +7,12 @@ body {
   font-weight: 400;
   margin: 0px;
   padding: 0px;
+
+  &.loading-layout {
+    .loading-background {
+      background-image: asset-url("impact_travel/loading.jpg");
+    }
+  }
 }
 .mb5 {
   margin-bottom: 5px;

--- a/app/views/layouts/impact_travel/loading.html.erb
+++ b/app/views/layouts/impact_travel/loading.html.erb
@@ -13,13 +13,14 @@
     <% end %>
   </head>
 
-  <body class="full">
+  <body class="full loading-layout">
     <div class="global-wrap">
 
       <div class="full-page">
         <div class="bg-holder full">
           <div class="bg-mask"></div>
-          <div class="bg-img" style="background-image:url(<%= asset_path "impact_travel/loading.jpg"%>);"></div>
+          <div class="bg-img loading-background"></div>
+
           <div class="bg-holder-content full text-white text-center">
             <div class="full-center">
               <div class="container">


### PR DESCRIPTION
In the loading page, we have a background image as inline style, which is making it very hard for white label to customize. This commit will extract the inline style and move it to `loading` style, so it should be very easier to mange from a white label now.