### PR TITLE
Fix landing page instructions

### DIFF
--- a/app/views/impact_travel/landings/show.html.erb
+++ b/app/views/impact_travel/landings/show.html.erb
@@ -1,6 +1,7 @@
 <div>
-  Override this layout in "app/view/layouts/landing" <br />
-  Override this page in "app/view/landings/show"
+  Override this layout in "app/views/layouts/impact_travel/landing.html.erb"
+  <br />
+  Override this page in "app/views/impact_travel/landings/show.html.erb"
 </div>
 
 <br />


### PR DESCRIPTION
In the landing page template, the path it was instructing it not valid, as the engine is name spaced as `impact_travel` so those template show maintain those consistency.

This commit changes those path to be the correct template path