### PR TITLE
Add `hotel_id` as permitted params

### DIFF
--- a/app/controllers/impact_travel/bookings_controller.rb
+++ b/app/controllers/impact_travel/bookings_controller.rb
@@ -58,10 +58,10 @@ module ImpactTravel
 
     def booking_params
       params.require(:booking).permit(
-        :hotel_name, :hotel_price, :promo_rate, :hotel_score,
-        :hotel_total_reviews, :hotel_description, :hotel_currency,
-        :first_name, :last_name, :email, :phone, :address, :city,
-        :zip, :country, :special_request
+        :hotel_id, :hotel_name, :hotel_price, :promo_rate,
+        :hotel_score, :hotel_total_reviews, :hotel_description,
+        :hotel_currency, :first_name, :last_name, :email, :phone,
+        :address, :city, :zip, :country, :special_request
       )
     end
   end

--- a/app/views/impact_travel/bookings/new.html.erb
+++ b/app/views/impact_travel/bookings/new.html.erb
@@ -91,7 +91,7 @@
               <% end %>
             </div>
 
-            <div id="result"></div>  
+            <div id="result"></div>
           </div>
 
           <!-- Sidebars -->


### PR DESCRIPTION
The current hotel bookings page, the engine is throwing an error as the `hotel_id` is not included into the permitted params list

This commit add the `hotel_id` to the permitted parameter list