### PR TITLE
Add validations for login model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
@@ -218,6 +220,7 @@ DEPENDENCIES
   factory_girl
   impact_travel!
   rspec-rails
+  shoulda-matchers (~> 3.1)
   sqlite3
   webmock (~> 2.0)
 

--- a/app/models/impact_travel/login.rb
+++ b/app/models/impact_travel/login.rb
@@ -1,13 +1,16 @@
 module ImpactTravel
   class Login < ImpactTravel::Base
     attr_accessor :name, :password
+    validates :name, :password, presence: true
 
     def attributes
       { name: name, password: password }
     end
 
     def authenticate
-      @response = DiscountNetwork::Session.create(attributes)
+      if valid?
+        @response = DiscountNetwork::Session.create(attributes)
+      end
     rescue RestClient::Unauthorized
     end
 

--- a/impact_travel.gemspec
+++ b/impact_travel.gemspec
@@ -25,8 +25,9 @@ Gem::Specification.new do |s|
   s.add_dependency "simple_form", "~> 3.2.1"
   s.add_dependency "will_paginate", "~> 3.0.6"
 
-  s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rspec-rails"
   s.add_development_dependency "capybara"
+  s.add_development_dependency "rspec-rails"
+  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "shoulda-matchers", "~> 3.1"
   s.add_development_dependency "webmock", "~> 2.0"
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -18,7 +18,6 @@ describe ImpactTravel::SessionsController do
     context "subscriber provides invalid credentials" do
       it "re render the login page" do
         subscriber = build(:login, name: nil)
-        stub_unauthorized_dn_api_reqeust("sessions")
         post :create, login: login_params(subscriber)
 
         expect(response).to redirect_to(new_session_path)

--- a/spec/models/login_spec.rb
+++ b/spec/models/login_spec.rb
@@ -1,6 +1,11 @@
 require "spec_helper"
 
 describe ImpactTravel::Login do
+  describe ".validations" do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :password }
+  end
+
   describe "#attributes" do
     it "returns the attributes as hash" do
       login = build(:login)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path("../dummy/config/environment.rb", __FILE__)
 require "rspec/rails"
 require "discountnetwork/rspec"
 require "factory_girl"
+require "shoulda-matchers"
 
 Dir[ImpactTravel::Engine.root.join("spec/support/**/*.rb")].each do |file|
   require file
@@ -21,9 +22,10 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   # Support Helpers
-  config.include Feature::AuthenticationHelpers
   config.include SignInHelpers
   config.include ProviderHelpers
+  config.include Feature::AuthenticationHelpers
+  config.include Shoulda::Matchers::ActiveModel
 end
 
 def restore_configuration_to_default


### PR DESCRIPTION
We do not have any validations for `login`, that's why when ever user tries to create a new session then we send an API request regardless the attributes are empty or not.

This commit changes this behavior, and add validations to `login` model, so no it will ensure, non-empty data are present before making any actual API request.