### PR TITLE
Fix postable provider link issue

### DIFF
--- a/app/views/impact_travel/providers/index.html.erb
+++ b/app/views/impact_travel/providers/index.html.erb
@@ -58,13 +58,13 @@
 
                 <div class="content-btn">
                   <% if provider.postable == true %>
-                    <%= form_for :postable, url: provider.link do |f| %>
-                      <%= f.submit(
-                        I18n.t("impact_travel.providers.book_now"),
-                        class: "btn btn-primary"
-                      )%>
-                    <% end %>
-
+                    <form method="POST" action="<%= provider.link %>">
+                      <input type="hidden" name="siteid" value="27613" />
+                      <input type="submit"
+                             name="commit"
+                             value="<%= impact_t("providers", "book_now") %>"
+                             class="btn btn-primary">
+                    </form>
                   <% else %>
                     <%= link_to(
                       I18n.t("impact_travel.providers.browse_button"),


### PR DESCRIPTION
Some provider requires some specific format and a specific site id before requesting those protected links, but the site id in the params is not working as expected.

This commit changes this and use the `site_id` as hard coded value in the form and that should fix that issue.