### PR TITLE
Add support for instant booking provider

### DIFF
--- a/app/controllers/impact_travel/instants_controller.rb
+++ b/app/controllers/impact_travel/instants_controller.rb
@@ -1,0 +1,17 @@
+module ImpactTravel
+  class InstantsController < ApplicationController
+    before_action :require_login
+    before_action :set_auth_token
+
+    def show
+      provider = Provider.find(instant_provider_slug)
+      redirect_to(provider.link)
+    end
+
+    private
+
+    def instant_provider_slug
+      "instant"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,5 @@ ImpactTravel::Engine.routes.draw do
   resources :policies, :terms, only: :index
   resource :price_guarantee, :cancellation, :privacy, only: :show
   resource :reservation_guarantee, :refund, only: :show
+  resource :instant, as: :instant_provider, only: :show
 end

--- a/spec/features/subscriber_browse_instant_booking_provider_spec.rb
+++ b/spec/features/subscriber_browse_instant_booking_provider_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+feature "Instant booking provider" do
+  scenario "subscriber browse instant booking provider" do
+    login_with_valid_credentials
+
+    stub_provider_find_by_slug_api(instant_provider_slug)
+    visit impact_travel.instant_provider_path
+
+    expect(current_path).not_to eq(impact_travel.instant_provider_path)
+  end
+
+  def instant_provider_slug
+    "instant"
+  end
+end


### PR DESCRIPTION
Recently we got a new white label through instant travel and it works little bit different than other white label, and it also has single sign on that our backend API already implemented

This commit adds a new routes, where we are calling the new API endpoints which handles all underlying tasks for single sign on and it responses with the same structure as other provider, all it's doing is redirecting the user to that custom url.