### PR TITLE
Extract company information to configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
-    countries (2.1.1)
+    countries (2.1.2)
       i18n_data (~> 0.8.0)
       money (~> 6.9)
       sixarm_ruby_unaccent (~> 1.1)
@@ -191,7 +191,7 @@ GEM
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
-    sixarm_ruby_unaccent (1.1.2)
+    sixarm_ruby_unaccent (1.2.0)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)
     sprockets (3.7.1)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ ImpactTravel.configure do |config|
   config.title = "Application Name / Title"
   config.abbreviation = "Application abbreviation"
   config.phone = "Contact Number for the app"
+  config.country = "The Country"
+  config.address = "Company registered address"
   config.stylesheet = "custom.stylesheet"
   config.slides = ["slide-1.jpg", "slide-2.jpg"]
 
@@ -97,10 +99,9 @@ existing design unaffected. The resources that support `content` are
 ## Development
 
 We are following Sandi Metz's Rules for this application, you can read the
-[description of the rules here]
-(http://robots.thoughtbot.com/post/50655960596/sandi-metz-rules-for-developers). All new code should follow these rules. If you make changes in a pre-existing
-file that violates these rules you should fix the violations as part of
-your contribution.
+[description of the rules here][sandi-metz]. All new code should follow these
+rules. If you make changes in a pre-existing file that violates these rules you
+should fix the violations as part of your contribution.
 
 ### Setup
 
@@ -133,15 +134,17 @@ Here are a few technical guidelines to follow:
 1. [Squash your commits][squash] after receiving feedback.
 1. Party!
 
-[issues]: https://github.com/abunashir/impact-travel/issues
-[squash]: https://github.com/thoughtbot/guides/tree/master/protocol/git#write-a-feature
-
 ## Credits
 
 <img src="https://www.impactservices.io/images/logo-impact-services.png" width="266" alt="Impact Services Co. Ltd.">
 
 This application is developed, maintained and funded by [Impact Services Co.
-Ltd.] (https://www.impactservices.co.th)
+Ltd.][impactservices]
 
-Thank you to all [the contributors]
-(https://github.com/abunashir/impact-travel/graphs/contributors)
+Thank you to all [the contributors][contributors].
+
+[issues]: https://github.com/abunashir/impact-travel/issues
+[squash]: https://github.com/thoughtbot/guides/tree/master/protocol/git#write-a-feature
+[sandi-metz]: http://robots.thoughtbot.com/post/50655960596/sandi-metz-rules-for-developers
+[contributors]: https://github.com/abunashir/impact-travel/graphs/contributors
+[impactservices]: https://www.impactservices.co.th

--- a/app/helpers/impact_travel/theme_helper.rb
+++ b/app/helpers/impact_travel/theme_helper.rb
@@ -60,6 +60,14 @@ module ImpactTravel
       @site_abbreviation ||= ImpactTravel.configuration.abbreviation
     end
 
+    def site_country
+      @site_country ||= ImpactTravel.configuration.country
+    end
+
+    def site_address
+      @site_address ||= ImpactTravel.configuration.address
+    end
+
     def home_slides
       @home_slides ||= ImpactTravel.configuration.slides
     end

--- a/app/views/impact_travel/terms/_content.html.erb
+++ b/app/views/impact_travel/terms/_content.html.erb
@@ -148,7 +148,7 @@
 <p>Failure by us to enforce a right does not result in waiver of such right. You may not assign or transfer your rights. We may amend the Terms of Use at any time by posting a variation on the Site. The latest version of the Terms of Use will supersede all previous versions.</p>
 
 <h4>12. About <%= site_abbreviation %> - FAQs</h4>
-<p>All of our services are rendered by <%= site_title %>, which is a private limited liability company, incorporated under the laws of [Country], having its registered address at [offical address for the company].</p>
+<p>All of our services are rendered by <%= site_title %>, which is a private limited liability company, incorporated under the laws of <%= site_country %>, having its registered address at <%= site_address %>.</p>
 
 <p><%= site_abbreviation %> and its related companies have various subsidiaries, branches and offices throughout the world. The subsidiaries, branches and offices only provide an internal supporting role to and for the benefit of <%= site_abbreviation %>. These subsidiaries, branches and offices (as well as any other affiliated companies) do not have any power or authority to render the service, to represent <%= site_abbreviation %> or to enter into any contract in the name of, for or on behalf of <%= site_abbreviation %>.</p>
 

--- a/lib/impact_travel/configuration.rb
+++ b/lib/impact_travel/configuration.rb
@@ -3,6 +3,7 @@ module ImpactTravel
     attr_accessor :api_key, :logo, :logo_inverse, :title, :abbreviation
     attr_accessor :stylesheet, :keywords, :description, :author, :phone
     attr_accessor :domain, :facebook, :twitter, :instagram, :slides
+    attr_accessor :country, :address
 
     def initialize
       @domain ||= "discountnetwork.io"

--- a/spec/dummy/config/initializers/impact_travel.rb
+++ b/spec/dummy/config/initializers/impact_travel.rb
@@ -4,6 +4,8 @@ ImpactTravel.configure do |config|
   config.title = "Discount Network"
   config.phone = "+1 888 123 456 7890"
   config.abbreviation = "DN"
+  config.country = "United States"
+  config.address = "123, Mountain View, CA, USA"
 
   config.stylesheet = "custom.style"
   config.keywords = "Travel, Leisure, Discount, Tours, Cruises"

--- a/spec/impact_travel/configuration_spec.rb
+++ b/spec/impact_travel/configuration_spec.rb
@@ -18,6 +18,8 @@ describe ImpactTravel::Configuration do
       site_abbreviation = "IT"
       site_logo = "logo.png"
       site_contact = "+1 123 456 789 1023"
+      site_country = "United States"
+      site_address = "123, New York, USA"
 
       site_keywords = "travel, discount"
       site_description = "Travel the world in cheapest price"
@@ -33,6 +35,8 @@ describe ImpactTravel::Configuration do
         config.description = site_description
         config.author = site_author
         config.phone = site_contact
+        config.country = site_country
+        config.address =site_address
         config.stylesheet = site_stylesheet
       end
 
@@ -43,6 +47,8 @@ describe ImpactTravel::Configuration do
       expect(configuration.title).to eq(site_title)
       expect(configuration.phone).to eq(site_contact)
       expect(configuration.author).to eq(site_author)
+      expect(configuration.country).to eq(site_country)
+      expect(configuration.address).to eq(site_address)
       expect(configuration.keywords).to eq(site_keywords)
       expect(configuration.stylesheet).to eq(site_stylesheet)
       expect(configuration.description).to eq(site_description)


### PR DESCRIPTION
Currently, we are using company address and selling country to some of the terms and policies related pages, but these values are static in the engine and it forces us to override those in application.

This commit extract those information to a configuration, so now we can easily reuse those content by simplify providing those info as configuration and everything else should work fine.