### PR TITLE
Remove shopping icon form home page

### DIFF
--- a/app/views/impact_travel/homes/show.html.erb
+++ b/app/views/impact_travel/homes/show.html.erb
@@ -76,8 +76,8 @@
               <li>
                 <%= link_to shopping_path do %>
                   <div class="item-service-line">
-                    <i class="fa fa-shopping-cart"></i>
-                    <h5>Shopping</h5>
+                    <i class="fa fa-phone"></i>
+                    <h5>Concierge</h5>
                   </div>
                 <% end %>
               </li>


### PR DESCRIPTION
Recently, we've had some changes regarding the shopping provider, but there still seems be another icon on the home page, which is creating some confusion between our marketers.

This commit removes that link and changes that with one of our existing concierge service icon.