### PR TITLE
Remove broken links from the sidebar

### DIFF
--- a/app/views/impact_travel/application/_sidebar_nav.html.erb
+++ b/app/views/impact_travel/application/_sidebar_nav.html.erb
@@ -6,20 +6,11 @@
     <i class="fa fa-user"></i>
     <%= link_to "Profile", account_path %><br />
 
-    <i class="fa fa-suitcase"></i>
-    <%= link_to "Bookings", bookings_path %><br />
-
-    <!-- <i class="fa fa-rocket"></i>
-    <%= link_to "Subscription", "#" %><br /> -->
-
     <i class="fa fa-users"></i>
     <%= link_to "Friends & Family", supplementaries_path %><br />
 
     <i class="fa fa-key"></i>
     <%= link_to "Change password", edit_account_password_path %><br />
-
-    <i class="fa fa-question-circle"></i>
-    <%= link_to "Need help?", contact_path %>
   </address>
 </aside>
 


### PR DESCRIPTION
In the user accounts page sidebar, there seems to be two invalid links and this commit remove those links for now, until we have something permanent for that sidebar.