### PR TITLE
Add support to create new account

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       bootstrap-sass (~> 3.3.7)
       coffee-rails
       country_select
-      discountnetwork (~> 0.1.2)
+      discountnetwork (~> 0.1.3)
       font-awesome-rails
       jquery-rails
       rails (>= 5.0.0)
@@ -68,6 +68,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -88,7 +89,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     diff-lcs (1.2.5)
-    discountnetwork (0.1.2)
+    discountnetwork (0.1.3)
       rest-client (~> 2.0)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -121,12 +122,15 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    money (6.13.0)
+    money (6.13.1)
       i18n (>= 0.6.4, <= 2)
     netrc (0.11.0)
     nio4r (1.2.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (2.0.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -238,6 +242,7 @@ DEPENDENCIES
   capybara
   factory_girl
   impact_travel!
+  pry
   rails-controller-testing
   rspec-rails
   shoulda-matchers (~> 3.1)

--- a/app/controllers/impact_travel/application_controller.rb
+++ b/app/controllers/impact_travel/application_controller.rb
@@ -12,6 +12,12 @@ module ImpactTravel
       end
     end
 
+    def allow_signup
+      unless allow_signup?
+        redirect_to(new_session_path)
+      end
+    end
+
     def sign_in(user)
       session[:auth_token] = user.token
       session[:subscription_status] = user.subscription_status
@@ -37,6 +43,10 @@ module ImpactTravel
 
     def set_auth_token
       DiscountNetwork.configuration.auth_token = user_auth_token
+    end
+
+    def allow_signup?
+      ImpactTravel.configuration.allow_signup === true
     end
 
     def set_app_session(key, value)

--- a/app/models/impact_travel/subscriber.rb
+++ b/app/models/impact_travel/subscriber.rb
@@ -14,6 +14,12 @@ module ImpactTravel
       end
     end
 
+    def register
+      if valid?
+        @response = DiscountNetwork::Account.create(attributes)
+      end
+    end
+
     def activate
       if token && valid?
         @response = DiscountNetwork::Activation.activate(token, attributes)

--- a/app/views/impact_travel/accounts/new.html.erb
+++ b/app/views/impact_travel/accounts/new.html.erb
@@ -1,0 +1,100 @@
+<!-- Section Title-->    
+<div class="section-title-01">
+  <!-- Parallax Background -->
+  <div class="bg_parallax image_05_parallax"></div>
+  <!-- Parallax Background -->
+
+  <!-- Content Parallax-->
+  <div class="opacy_bg_02">
+    <div class="container">
+      <h1>New Account</h1>
+      <div class="crumbs">
+        <ul>
+          <li>Welcome to <%= site_title %></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <!-- End Content Parallax--> 
+</div>
+<!-- End Section Title-->
+
+<!--Content Central -->
+<div class="content-central">
+  <!-- Shadow Semiboxed -->
+  <div class="semiboxshadow text-center">
+    <%= image_tag(
+      "impact_travel/result-bg.png", class: "img-responsive"
+    ) %>
+  </div>
+  <!-- End Shadow Semiboxed -->
+
+  <!-- End content info - page Fill with -->
+  <div class="content_info">
+    <div class="paddings-mini">
+      <div class="container">
+        <div class="row">
+
+          <div class="col-md-8">
+            <h3>Subscriber details</h3>
+            <div class="form_holder">
+              <%=
+                simple_form_for(
+                  @subscriber,
+                  url: account_path,
+                  html: { class: "travelia_form" }
+                ) do |f| %>
+
+                <%= f.input :first_name %>
+                <%= f.input :middle_name %>
+                <%= f.input :last_name %>
+                <%= f.input :spouse_name %>
+                <%= f.input(
+                  :sex,
+                  as: :radio_buttons,
+                  collection: [["Male", "male"], ["Female", "female"]],
+                ) %>
+                <%= f.input :email %>
+                <%= f.input :phone %>
+                <%= f.input :mobile %>
+                <%= f.input :office_phone %>
+                <%= f.input :address %>
+                <%= f.input :city %>
+                <%= f.input :state, label: "Province" %>
+                <%= f.input :zip, label: "Post Code" %>
+                <%= f.input :country, input_html: {class: "form-control"} %>
+                <%= f.input :username %>
+                <%= f.input :password %>
+                <%= f.input :password_confirmation %>
+
+                <%= f.button(
+                  :submit,
+                  "Create Now",
+                  class: "btn btn-primary"
+                ) %>
+              <% end %>
+            </div>
+
+            <div id="result"></div>  
+          </div>
+
+          <!-- Sidebars -->
+          <div class="col-md-4">
+            <aside>
+              <h4> &nbsp; </h4>
+
+              <address>
+                <strong>Need help ?</strong><br>
+                <i class="fa fa-envelope"></i>
+                <%= link_to(support_email, "mailto:#{support_email}") %>
+              </address>
+          </div>
+          <!-- End Sidebars -->
+
+        </div>
+      </div>
+    </div>
+  </div>
+  <!-- End content info - page Fill with  --> 
+</div>
+<!-- End Content Central -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,11 @@ en:
     updated: "You changes has been saved successfully!"
     activated: "Your account has been activated!"
 
+    create:
+      success:
+        "Account has been created! Please check your inbox for
+        activation email"
+
   activation:
     invalid: "Please provide all the required fields to activate your account"
 

--- a/impact_travel.gemspec
+++ b/impact_travel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bootstrap-sass", "~> 3.3.7"
   s.add_dependency "coffee-rails"
   s.add_dependency "country_select"
-  s.add_dependency "discountnetwork", "~> 0.1.2"
+  s.add_dependency "discountnetwork", "~> 0.1.3"
   s.add_dependency "font-awesome-rails"
   s.add_dependency "jquery-rails"
   s.add_dependency "rails", ">= 5.0.0"
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "simple_form"
   s.add_dependency "will_paginate", "~> 3.0.6"
 
+  s.add_development_dependency "pry"
   s.add_development_dependency "capybara"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "sqlite3"

--- a/lib/impact_travel/configuration.rb
+++ b/lib/impact_travel/configuration.rb
@@ -3,9 +3,10 @@ module ImpactTravel
     attr_accessor :api_key, :logo, :logo_inverse, :title, :abbreviation
     attr_accessor :stylesheet, :keywords, :description, :author, :phone
     attr_accessor :domain, :facebook, :twitter, :instagram, :slides
-    attr_accessor :country, :address
+    attr_accessor :country, :address, :allow_signup
 
     def initialize
+      @allow_signup ||= false
       @domain ||= "discountnetwork.io"
       @slides ||= ["impact_travel/slide.jpg"]
     end

--- a/spec/features/visitor_creates_new_account_spec.rb
+++ b/spec/features/visitor_creates_new_account_spec.rb
@@ -1,0 +1,76 @@
+require "ostruct"
+require "spec_helper"
+
+feature "Account creation" do
+  scenario "create new account with valid information" do
+    subscriber = build_user
+    set_allow_signup_configuration(true)
+    stub_account_create_api(subscriber.to_h)
+
+    visit impact_travel.new_account_path
+
+    fill_in "subscriber_first_name", with: subscriber.first_name
+    fill_in "subscriber_last_name", with: subscriber.last_name
+    fill_in "subscriber_email", with: subscriber.email
+    fill_in "subscriber_mobile", with: subscriber.mobile
+    fill_in "subscriber_phone", with: subscriber.phone
+    fill_in "subscriber_address", with: subscriber.address
+    fill_in "subscriber_city", with: subscriber.city
+    fill_in "subscriber_state", with: subscriber.state
+    fill_in "subscriber_zip", with: subscriber.zip
+    fill_in "subscriber_username", with: subscriber.username
+    fill_in "subscriber_password", with: subscriber.password
+    fill_in "Password confirmation", with: subscriber.password
+    select "United States", from: "subscriber_country"
+
+    click_on "Create Now"
+
+    expect(current_path).to eq(impact_travel.new_session_path)
+    expect(page).to have_content(I18n.t("account.create.success"))
+  end
+
+  scenario "does not create new account with invalid data" do
+    set_allow_signup_configuration(true)
+    visit impact_travel.new_account_path
+
+    click_on "Create Now"
+
+    expect(page).to have_content("Mobilecan't be blank")
+    expect(page).to have_content("First namecan't be blank")
+    expect(current_path).to eq(impact_travel.account_path)
+  end
+
+  scenario "user tries create account on non-supported site" do
+    set_allow_signup_configuration(false)
+
+    visit impact_travel.new_account_path
+
+    expect(current_path).to eq(impact_travel.new_session_path)
+  end
+
+  def set_allow_signup_configuration(status = true)
+    ImpactTravel.configuration.allow_signup = status
+  end
+
+  def build_user
+    OpenStruct.new(
+      first_name: "John",
+      middle_name: "",
+      last_name: "Doe",
+      spouse_name: "",
+      sex: "",
+      email: "john.doe@example.com",
+      phone: "123 456 7890",
+      mobile: "+1 888 123 456 7890",
+      office_phone: "",
+      address: "Hose #1, Main Street",
+      city: "New York",
+      state: "New York",
+      zip: "123 ABC",
+      country: "US",
+      username: "john.doe",
+      password: "secret_password",
+      password_confirmation: "secret_password",
+    )
+  end
+end

--- a/spec/impact_travel/configuration_spec.rb
+++ b/spec/impact_travel/configuration_spec.rb
@@ -38,6 +38,7 @@ describe ImpactTravel::Configuration do
         config.country = site_country
         config.address =site_address
         config.stylesheet = site_stylesheet
+        config.allow_signup = true
       end
 
       configuration = ImpactTravel.configuration
@@ -53,6 +54,7 @@ describe ImpactTravel::Configuration do
       expect(configuration.stylesheet).to eq(site_stylesheet)
       expect(configuration.description).to eq(site_description)
       expect(configuration.abbreviation).to eq(site_abbreviation)
+      expect(configuration.allow_signup).to be_truthy
     end
   end
 


### PR DESCRIPTION
Recently, Discount Network added support to create a new account in some specific white labels. So, if some white label has been approved for this then they would like to offer this to the user

This commit take this decision into consideration, so now if a white label has this option enabled then they should have an easy access to that feature from this engine.