### PR TITLE
Specify package id on account creation

### DIFF
--- a/app/models/impact_travel/subscriber.rb
+++ b/app/models/impact_travel/subscriber.rb
@@ -6,7 +6,7 @@ module ImpactTravel
     attr_accessor :password_confirmation, :status, :name, :token
 
     validates :first_name, :last_name, :email, :mobile, :address, presence: true
-    validates :city, :state, :zip, :country, presence: true
+    validates :phone, :city, :state, :zip, :country, presence: true
 
     def save
       if valid?
@@ -16,7 +16,9 @@ module ImpactTravel
 
     def register
       if valid?
-        @response = DiscountNetwork::Account.create(attributes)
+        @response = DiscountNetwork::Account.create(
+          attributes.merge(package_id: default_package_id),
+        )
       end
     end
 
@@ -46,6 +48,12 @@ module ImpactTravel
         password: password,
         password_confirmation: password_confirmation,
       }.compact
+    end
+
+    private
+
+    def default_package_id
+      ImpactTravel.configuration.default_package_id
     end
   end
 end

--- a/lib/impact_travel/configuration.rb
+++ b/lib/impact_travel/configuration.rb
@@ -3,7 +3,7 @@ module ImpactTravel
     attr_accessor :api_key, :logo, :logo_inverse, :title, :abbreviation
     attr_accessor :stylesheet, :keywords, :description, :author, :phone
     attr_accessor :domain, :facebook, :twitter, :instagram, :slides
-    attr_accessor :country, :address, :allow_signup
+    attr_accessor :country, :address, :allow_signup, :default_package_id
 
     def initialize
       @allow_signup ||= false

--- a/spec/features/visitor_creates_new_account_spec.rb
+++ b/spec/features/visitor_creates_new_account_spec.rb
@@ -71,6 +71,7 @@ feature "Account creation" do
       username: "john.doe",
       password: "secret_password",
       password_confirmation: "secret_password",
+      package_id: nil,
     )
   end
 end


### PR DESCRIPTION
The whole subscription process is directly involve with the packages, and it also define the subscriber's status on how to charge and when to charge and which is necessary.

This commit adds another configuration option to provide a `package_id` and it will be used by default if no package is selected.