### PR TITLE
Point hotels pages for book now action

### DIFF
--- a/app/views/impact_travel/homes/show.html.erb
+++ b/app/views/impact_travel/homes/show.html.erb
@@ -12,7 +12,7 @@
     <div class="title-header">
       <%= link_to(
         I18n.t("impact_travel.home.book_button"),
-        instant_provider_path,
+        hotels_path,
         target: "_blank",
         class: "btn btn-primary",
         style: "padding: 13px 30px"


### PR DESCRIPTION
The home page book action was redirecting our users to one of the partner's white label, but since we have some issue so this commit changes this to link our hotels pages, so now user will see listing page and they can choose a partner to book.